### PR TITLE
feat: Novos comandos no makefile + Atualização de docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 #!/bin/bash
 .PHONY: default
 .SILENT:
-
+# VARIABLES 
+SERVICE ?=all
+FRONT_SERVICE ?=vue-knowledge-front
+STORYBOOK_SERVICE ?=storybook
 
 default:
 
@@ -9,9 +12,19 @@ setup:
 	docker network create vue-knowledge-front-network || true
 
 start:
+ifeq ($(SERVICE), all)
 	docker-compose -f docker-compose.yml up --detach --force-recreate --build --remove-orphans
+else
+	docker-compose -f docker-compose.yml up $(SERVICE) --detach --force-recreate --build --remove-orphans	
+endif
 
-start_no_detach:
+start-front: 
+	docker-compose -f docker-compose.yml up $(FRONT_SERVICE) --detach --force-recreate --build --remove-orphans
+
+start-storybook: 
+	docker-compose -f docker-compose.yml up $(STORYBOOK_SERVICE) --detach --force-recreate --build --remove-orphans
+
+start-no-detach:
 	docker-compose -f docker-compose.yml up --force-recreate --build --remove-orphans
 
 stop:

--- a/README.md
+++ b/README.md
@@ -13,10 +13,27 @@ Para rodar o ambiente de desenvolvimento , pela primeira vez execute:
 make setup
 ```  
 
-Para rodar o ambiente em modo background:  
+Para rodar o ambiente em modo background:
+> O storybook roda juntamente do container da aplicação  
 
 ```shell
 make start
+```
+
+Para rodar apenas o serviço do front sem o storybook:
+
+```shell
+make start-front
+# or
+make start SERVICE=vue-knowledge-front
+```
+
+Para rodar apenas o serviço do storybook sem o front:
+
+```shell
+make start-storybook
+# or
+make start SERVICE=storybook
 ```
 
 Na primeira vez que esse comando é executado ele pode demorar a executar o front. Se pode observar os logs do comando utilizando o modo interativo ou o comando:  
@@ -28,16 +45,16 @@ make logs
 Para rodar o ambiente em modo interativo:  
 
 ```shell
-make start_no_detach
+make start-no-detach
 ```
  
-Para acessar o terminal interativo do container, rode:  
+Para acessar o terminal interativo do container front, rode:  
 
 ```shell
 make shell
 ```
 
-O make shell é recomendado para termos mais controle da aplicação. Dentro dele se pode executar diretamente o comando `npm run serve` e instalar libs necessárias.  
+O make shell é recomendado para termos mais controle da aplicação. Dentro dele se pode executar diretamente o comando `npm run serve` e/ou instalar libs necessárias.  
 
 > O storybook roda juntamente do container da aplicação
 > ### Porta exposta pelo container: 8080 e storybook 6006


### PR DESCRIPTION
### :pencil: Description
Essa PR cria novos comandos para controle do container através do arquivo Makefile.

Foram eles: 

 - O comando start se pode passar uma novo parametro `SERVICE` com o nome do serviço para rodar individualmente. 
 - Comando para rodar os start individual de cada serviço `make start-front` e `make start-storybook`

### :hammer\_and\_wrench: Changes
Commits relacionados.
### :warning: Notes
A partir dessa branch vamos mergiar em `dev` para depois subirmos um pacote de tag em `main`
